### PR TITLE
Translations update from Translate H5P

### DIFF
--- a/language/nb.json
+++ b/language/nb.json
@@ -27,7 +27,7 @@
             "label": "Ekstra hint"
           },
           {
-            "label": "Fest ord til rutenett.",
+            "label": "Fest ord til rutenett",
             "description": "Huk av dersom du ønsker å feste ordet til en spesifikk posisjon i rutenettet."
           },
           {
@@ -55,7 +55,7 @@
     },
     {
       "label": "Løsningsord",
-      "description": "Velg om du vil legge til et løsningsord som som er satt sammen av bokstaver i rutenettet. Løsningsordet vil kun vises dersom alle de korrekte bokstavene er på plass i kryssordet. Merk: Det er ingen tilgjengelighetsstøtte for denne funksjonen enda."
+      "description": "Velg om du vil legge til et løsningsord som er satt sammen av bokstaver i rutenettet. Løsningsordet vil kun vises dersom alle de korrekte bokstavene er på plass i kryssordet. Merk: Det er ingen tilgjengelighetsstøtte for denne funksjonen enda."
     },
     {
       "label": "Generell tilbakemelding",
@@ -138,7 +138,7 @@
       "description": "Disse valga gir deg kontroll over hvordan oppgava oppfører seg.",
       "fields": [
         {
-          "label": "Antall ord som skal vises.",
+          "label": "Antall ord som skal vises",
           "description": "Lag ei tilfeldig samling av ord fra databasen. Samlingen vil alltid som et minimum innholde de orda som er festa til rutenettet. Er dette feltet tomt eller har verdien 0, betyr dette at alle orda brukes."
         },
         {
@@ -150,7 +150,7 @@
         },
         {
           "label": "Gi straff",
-          "description": "Dersom denne funskjonen er valgt, vil hvert svar som er feil gi et fratrekk på ett poeng. "
+          "description": "Dersom denne funskjonen er valgt, vil hvert svar som er feil gi et fratrekk på ett poeng."
         },
         {
           "label": "Aktiver \"Prøv igjen\""
@@ -175,7 +175,7 @@
           "label": "Tekst for \"Sjekk\"-knapp",
           "default": "Sjekk"
         },
-         {
+        {
           "label": "Tekst for \"Legg inn\"-knapp",
           "default": "Legg inn"
         },
@@ -276,7 +276,7 @@
         {
           "description": "Oppgir lengden på ordet. @length er en variablel og vil bli bytta ut med sin respektive verdi.",
           "label": "Ordlengde",
-          "default": "Ordet har @length bokstaver."
+          "default": "Ordet har @length bokstaver"
         },
         {
           "label": "Tekstalternativ for \"Sjekk\"-knapp",
@@ -292,7 +292,7 @@
         },
         {
           "label": "Ditt resultat",
-          "description": "@score og @total er variabler og vil bli bytta ut med sine respektive verdier",
+          "description": "@score og @total er variabler og vil bli bytta ut med sine respektive verdier.",
           "default": "Du fikk @score av @total poeng."
         }
       ]

--- a/language/nl.json
+++ b/language/nl.json
@@ -293,7 +293,7 @@
         {
           "label": "Je resultaat",
           "description": "@score en @total zijn variabelen en zullen worden vervangen door hun respectievelijke waarden.",
-          "default": "Je hebt @score van de @total punten"
+          "default": "Je hebt @score van de @total punten."
         }
       ]
     }

--- a/language/nn.json
+++ b/language/nn.json
@@ -17,11 +17,11 @@
         "fields": [
           {
             "label": "Hint",
-            "description": "Hint til svaret"
+            "description": "Hint til svaret."
           },
           {
             "label": "Svar",
-            "description": "Svar til hintet"
+            "description": "Svar til hintet."
           },
           {
             "label": "Ekstra hint"
@@ -32,15 +32,15 @@
           },
           {
             "label": "Rad",
-            "description": "Radnummeret svaret skal starte frå"
+            "description": "Radnummeret svaret skal starte frå."
           },
           {
             "label": "Kolonne",
-            "description": "Kolonnenummeret svaret skal starte frå"
+            "description": "Kolonnenummeret svaret skal starte frå."
           },
           {
             "label": "Retning",
-            "description": "Retninga på svaret",
+            "description": "Retninga på svaret.",
             "options": [
               {
                 "label": "Vassrett"
@@ -67,7 +67,7 @@
             }
           ],
           "label": "Definer standard tilbakemelding for alle poengsummane",
-          "description": "Klikk på \"Legg til poengområde\"-knappen for å leggje til dei områda du behøver. Døme: 0–49 % Låg poengsum, 50–79 % Middels poengsum, 80–100 % Høg poengsum",
+          "description": "Klikk på \"Legg til poengområde\"-knappen for å leggje til dei områda du behøver. Døme: 0–49 % Låg poengsum, 50–79 % Middels poengsum, 80–100 % Høg poengsum!",
           "entity": "Område",
           "field": {
             "fields": [
@@ -150,7 +150,7 @@
         },
         {
           "label": "Gi straff",
-          "description": "Dersom denne funksjonen er vald, vil kvart svar som er feil gi eit fråtrekk på eitt poeng. "
+          "description": "Dersom denne funksjonen er vald, vil kvart svar som er feil gi eit fråtrekk på eitt poeng."
         },
         {
           "label": "Aktiver \"Prøv igjen\""
@@ -262,7 +262,7 @@
         {
           "description": "Gir opp ekstra hint. @clue er ein variabel som vil bli bytt ut med den respektive verdien sin.",
           "label": "Ekstra hint for",
-          "default": "Opn ekstra hint for @clue."
+          "default": "Opn ekstra hint for @clue"
         },
         {
           "label": "Tom rute",
@@ -276,7 +276,7 @@
         {
           "description": "Gir opp kor langt ordet er. @length er ein variabel og vil bli bytt ut med den respektive verdien sin.",
           "label": "Ordlengd",
-          "default": "Ordet har @length bokstavar."
+          "default": "Ordet har @length bokstavar"
         },
         {
           "label": "Tekstalternativ for \"Sjekk\"-knapp",


### PR DESCRIPTION
Translations update from [Translate H5P](https://translate-h5p.tk/weblate/projects/h5p/h5p-crossword/)
for H5P/h5p-crossword.



Current translation status:

![Weblate translation status](https://translate-h5p.tk/weblate/widgets/h5p/-/h5p-crossword/horizontal-auto.svg)
