### PR TITLE
Translations update from Translate H5P

### DIFF
--- a/language/nl.json
+++ b/language/nl.json
@@ -211,7 +211,7 @@
       ]
     },
     {
-      "label": "Voorlezer",
+      "label": "Schermlezer",
       "fields": [
         {
           "label": "Rasterbeschrijving van de kruiswoordpuzzel",


### PR DESCRIPTION
Translations update from [Translate H5P](https://translate-h5p.tk/weblate/projects/h5p/h5p-crossword/)
for H5P/h5p-crossword.



Current translation status:

![Weblate translation status](https://translate-h5p.tk/weblate/widgets/h5p/-/h5p-crossword/horizontal-auto.svg)
