### PR TITLE
Avoid keyboard navigation for empty cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider webpack",
+    "build": "cross-env NODE_ENV=production webpack",
     "watch": "webpack --watch"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "cross-env NODE_ENV=production webpack",
+    "build": "cross-env NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider webpack",
     "watch": "webpack --watch"
   },
   "repository": {

--- a/src/scripts/h5p-crossword-table.js
+++ b/src/scripts/h5p-crossword-table.js
@@ -389,6 +389,9 @@ export default class CrosswordTable {
       return false;
     }
     if (position.column < 0 || position.column > this.params.dimensions.columns - 1) {
+      return false;    		
+    }
+    if (this.checkEmpty(position.row, position.column)) {
       return false;
     }
 
@@ -411,6 +414,15 @@ export default class CrosswordTable {
     return true;
   }
 
+  
+  /**
+   * Check if cell is empty (not interactable).
+   * @param {number} position.row Cell row.
+   * @param {number} position.column Cell column.
+   */
+  checkEmpty(row, col) {
+    return document.querySelector("[data-col='"+(parseInt(col, 10))+"'][data-row='"+parseInt(row, 10)+"']").classList.contains('h5p-crossword-cell-empty');
+  }
 
   /**
    * Get information for other components.

--- a/src/scripts/h5p-crossword-table.js
+++ b/src/scripts/h5p-crossword-table.js
@@ -391,8 +391,8 @@ export default class CrosswordTable {
     if (position.column < 0 || position.column > this.params.dimensions.columns - 1) {
       return false;    		
     }
-    if (this.checkEmpty(position.row, position.column)) {
-      return false;
+    if (this.cells[position.row][position.column].getSolution() === null) {
+      return false; // Target cell is empty	
     }
 
     const targetCell = this.cells[position.row][position.column];
@@ -412,16 +412,6 @@ export default class CrosswordTable {
     this.focusCell(position, keepFocus);
 
     return true;
-  }
-
-  
-  /**
-   * Check if cell is empty (not interactable).
-   * @param {number} position.row Cell row.
-   * @param {number} position.column Cell column.
-   */
-  checkEmpty(row, col) {
-    return document.querySelector("[data-col='"+(parseInt(col, 10))+"'][data-row='"+parseInt(row, 10)+"']").classList.contains('h5p-crossword-cell-empty');
   }
 
   /**


### PR DESCRIPTION
This update will improve keyboard navigation and a11y by disabling possibility to navigate to cells that are not interactable.