### PR TITLE
JI-5467 return null when resume state is empty

### DIFF
--- a/src/scripts/h5p-crossword-content.js
+++ b/src/scripts/h5p-crossword-content.js
@@ -280,10 +280,15 @@ export default class CrosswordContent {
       return;
     }
 
+    const cells = this.table.getAnswers();
+    const focus = this.table.getFocus();
+    if (!cells.find((item) => item !== undefined) && typeof focus.position.row === 'undefined') {
+      return;
+    }
     return {
       crosswordLayout: this.crosswordLayout,
-      cells: this.table.getAnswers(),
-      focus: this.table.getFocus()
+      cells,
+      focus
     };
   }
 


### PR DESCRIPTION
This will return null for empty saved states so that the h5p core library will no longer incorrectly show the "Your progress was restored" message.
Without this change the progress restored message is incorrectly shown on h5p.com instances when the user enters no data and refreshes the page.