### PR TITLE
Replace 10 or more consecutive underscores with 9 in word clue used in xAP…

### DIFF
--- a/src/scripts/h5p-crossword-table.js
+++ b/src/scripts/h5p-crossword-table.js
@@ -1035,7 +1035,8 @@ export default class CrosswordTable {
   getXAPIDescription() {
     return this.params.words
       .map((word) => {
-        const clue = `${word.clueId} ${this.params.l10n[word.orientation]}: ${word.clue}`;
+        // The below replaceAll makes sure we don't get any unwanted XAPI_PLACEHOLDERs in the description:
+        const clue = `${word.clueId} ${this.params.l10n[word.orientation]}: ${word.clue.replaceAll(/_{10,}/gi, '_________')}`;
 
         const placeholders = [];
         if (this.params.scoreWords) {


### PR DESCRIPTION
Some authors are using 10 or more consecutive underscores in the Clue field. Since we're using the 10 underscores in the xAPI statement to signal a "blank", this becomes incompatible.

I must admit I haven't tested this code change, but theorietically it should do the trick.